### PR TITLE
Add Gubu to the list of type mapping projects.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 | [joi](https://github.com/sideway/joi) | ![GitHub stars](https://img.shields.io/github/stars/sideway/joi.svg?style=social&label=☆&maxAge=2592000) |
 | [TypeGraphQL](https://github.com/MichalLytek/type-graphql) | ![GitHub stars](https://img.shields.io/github/stars/MichalLytek/type-graphql.svg?style=social&label=☆&maxAge=2592000) |
 | [Deepkit](https://github.com/deepkit/deepkit-framework) | ![GitHub stars](https://img.shields.io/github/stars/deepkit/deepkit-framework.svg?style=social&label=☆&maxAge=2592000) |
+| [Gubu](https://github.com/rjrodger/gubu) | ![GitHub stars](https://img.shields.io/github/stars/rjrodger/gubu.svg?style=social&label=☆&maxAge=2592000) |
 
 ##### Code Generation / External Tool Projects
 


### PR DESCRIPTION
From the Gubu README:

>Gubu makes a best-effort to support TypeScript types. The intersection of the type of the schema and the type of the value is used as the return type. This almost always does what you want, especially with optional default values (from which types will be inferred) ... Sadly TypeScript does not provide runtime type information at present.