### PR TITLE
Add ttype-safe to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@
 | [ts-json-schema-generator](https://github.com/vega/ts-json-schema-generator) | ![GitHub stars](https://img.shields.io/github/stars/vega/ts-json-schema-generator.svg?style=social&label=☆&maxAge=2592000) |
 | [ts-type-checked](https://github.com/janjakubnanista/ts-type-checked) | ![GitHub stars](https://img.shields.io/github/stars/janjakubnanista/ts-type-checked.svg?style=social&label=☆&maxAge=2592000) |
 | [tst-reflect](https://github.com/Hookyns/tst-reflect) | ![GitHub stars](https://img.shields.io/github/stars/Hookyns/tst-reflect.svg?style=social&label=☆&maxAge=2592000) |
+| [ttype-safe](https://github.com/donflopez/ttype-safe) | ![GitHub stars](https://img.shields.io/github/stars/donflopez/ttype-safe.svg?style=social&label=☆&maxAge=2592000) |
 
 
 Please file an [issue](https://github.com/akutruff/typescript-needs-types/issues) or send a PR to add to this list.   Even if it's your own project and it has zero stars, you had to deal with this, so it goes on the list. 


### PR DESCRIPTION
I've created yet another version for type checks for what I think should be the default in TS.