### PR TITLE
Add typeschema to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@
 | [tst-reflect](https://github.com/Hookyns/tst-reflect) | ![GitHub stars](https://img.shields.io/github/stars/Hookyns/tst-reflect.svg?style=social&label=☆&maxAge=2592000) |
 | [ttype-safe](https://github.com/donflopez/ttype-safe) | ![GitHub stars](https://img.shields.io/github/stars/donflopez/ttype-safe.svg?style=social&label=☆&maxAge=2592000) |
 
+##### Unified Interface Projects
+
+| Project | Stars |
+| --- | --- |
+| [typeschema](https://github.com/decs/typeschema) | ![GitHub stars](https://img.shields.io/github/stars/decs/typeschema.svg?style=social&label=☆&maxAge=2592000) |
+
 
 Please file an [issue](https://github.com/akutruff/typescript-needs-types/issues) or send a PR to add to this list.   Even if it's your own project and it has zero stars, you had to deal with this, so it goes on the list. 
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@
 
 ### The Unfortunate List of Projects Working Around this Issue
 
+##### Adapter Projects
+
+| Project | Stars |
+| --- | --- |
+| [typeschema](https://github.com/decs/typeschema) | ![GitHub stars](https://img.shields.io/github/stars/decs/typeschema.svg?style=social&label=☆&maxAge=2592000) |
+
 ##### Type Mapping Projects
 
 | Project | Stars |
@@ -55,12 +61,6 @@
 | [ts-type-checked](https://github.com/janjakubnanista/ts-type-checked) | ![GitHub stars](https://img.shields.io/github/stars/janjakubnanista/ts-type-checked.svg?style=social&label=☆&maxAge=2592000) |
 | [tst-reflect](https://github.com/Hookyns/tst-reflect) | ![GitHub stars](https://img.shields.io/github/stars/Hookyns/tst-reflect.svg?style=social&label=☆&maxAge=2592000) |
 | [ttype-safe](https://github.com/donflopez/ttype-safe) | ![GitHub stars](https://img.shields.io/github/stars/donflopez/ttype-safe.svg?style=social&label=☆&maxAge=2592000) |
-
-##### Unified Interface Projects
-
-| Project | Stars |
-| --- | --- |
-| [typeschema](https://github.com/decs/typeschema) | ![GitHub stars](https://img.shields.io/github/stars/decs/typeschema.svg?style=social&label=☆&maxAge=2592000) |
 
 
 Please file an [issue](https://github.com/akutruff/typescript-needs-types/issues) or send a PR to add to this list.   Even if it's your own project and it has zero stars, you had to deal with this, so it goes on the list. 


### PR DESCRIPTION
I launched TypeSchema to help library developers like me (and product developers as well) decouple their code from specific validation libraries (like `zod` or `yup`) and make them more plug-n-play